### PR TITLE
 Rename machine names for Container and Width

### DIFF
--- a/templates/overrides/paragaphs/paragraph--sa-columns.html.twig
+++ b/templates/overrides/paragaphs/paragraph--sa-columns.html.twig
@@ -48,13 +48,13 @@
 %}
 
 {% set container_class_string = 'container' %}
-{% if paragraph.sa_width.value is not empty %}
-  {% set container_class_string = ' ' ~ paragraph.sa_width.value %}
+{% if paragraph.sa_container.value is not empty %}
+  {% set container_class_string = ' ' ~ paragraph.sa_container.value %}
 {% endif %}
 
-{% set col_class_string = '' %}
-{% if paragraph.sa_col.value is not empty %}
-  {% set col_class_string = ' ' ~ paragraph.sa_col.value %}
+{% set width_class_string = '' %}
+{% if paragraph.sa_width.value is not empty %}
+  {% set width_class_string = ' ' ~ paragraph.sa_width.value %}
 {% endif %}
 
 {% set margin_class_string = '' %}
@@ -105,9 +105,9 @@
 {% block paragraph %}
 <div{{ attributes.addClass(classes) }}>
   <div class="{{ container_class_string }}{{ bg_class_string }}{{ margin_class_string }}{{ padding_class_string }}">
-    {% if paragraph.sa_col.value is not empty %}
+    {% if paragraph.sa_width.value is not empty %}
       <div class="row justify-content-center">
-        <div class="{{ col_class_string }}">
+        <div class="{{ width_class_string }}">
     {% endif %}
       {% block content %}
           {{ content|without('sa_column_items') }}
@@ -119,7 +119,7 @@
           {% endfor %}
           </div>
       {% endblock %}
-    {% if paragraph.sa_col.value is not empty %}
+    {% if paragraph.sa_width.value is not empty %}
         </div>
       </div>
     {% endif %}

--- a/templates/overrides/paragaphs/paragraph--sa-side-by-side.html.twig
+++ b/templates/overrides/paragaphs/paragraph--sa-side-by-side.html.twig
@@ -57,13 +57,13 @@
 {% endif %}
 
 {% set container_class_string = '' %}
-{% if paragraph.sa_width.value is not empty %}
-  {% set container_class_string = ' ' ~ paragraph.sa_width.value %}
+{% if paragraph.sa_container.value is not empty %}
+  {% set container_class_string = ' ' ~ paragraph.sa_container.value %}
 {% endif %}
 
-{% set col_class_string = '' %}
-{% if paragraph.sa_col.value is not empty %}
-  {% set col_class_string = ' ' ~ paragraph.sa_col.value %}
+{% set width_class_string = '' %}
+{% if paragraph.sa_width.value is not empty %}
+  {% set width_class_string = ' ' ~ paragraph.sa_width.value %}
 {% endif %}
 
 {% set margin_class_string = '' %}
@@ -84,8 +84,8 @@
   <div{{attributes.addClass(classes)}}>
     <div class="{{ container_class_string }}{{ bg_class_string }}{{ margin_class_string }}{{ padding_class_string }}">
       <div class="row justify-content-center{{ textleft }}">
-        {% if col_class_string is not empty %}
-          <div class="{{ col_class_string }}">
+        {% if width_class_string is not empty %}
+          <div class="{{ width_class_string }}">
             <div class="row justify-content-center{{ textleft }}">
             {% endif %}
             <div class="align-self-center col-md-6">
@@ -101,7 +101,7 @@
                 {{ content.sa_description }}
               {% endif %}
             </div>
-            {% if col_class_string is not empty %}
+            {% if width_class_string is not empty %}
             </div>
           </div>
         {% endif %}

--- a/templates/overrides/paragaphs/paragraph.html.twig
+++ b/templates/overrides/paragaphs/paragraph.html.twig
@@ -48,13 +48,13 @@
 %}
 
 {% set container_class_string = 'container' %}
-{% if paragraph.sa_width.value is not empty %}
-  {% set container_class_string = ' ' ~ paragraph.sa_width.value %}
+{% if paragraph.sa_container.value is not empty %}
+  {% set container_class_string = ' ' ~ paragraph.sa_container.value %}
 {% endif %}
 
-{% set col_class_string = '' %}
-{% if paragraph.sa_col.value is not empty %}
-  {% set col_class_string = ' ' ~ paragraph.sa_col.value %}
+{% set width_class_string = '' %}
+{% if paragraph.sa_width.value is not empty %}
+  {% set width_class_string = ' ' ~ paragraph.sa_width.value %}
 {% endif %}
 
 {% set margin_class_string = '' %}
@@ -75,14 +75,14 @@
 {% block paragraph %}
 <div{{ attributes.addClass(classes) }}>
   <div class="{{ container_class_string }}{{ bg_class_string }}{{ margin_class_string }}{{ padding_class_string }}">
-    {% if paragraph.sa_col.value is not empty %}
+    {% if paragraph.sa_width.value is not empty %}
       <div class="row justify-content-center">
-        <div class="{{ col_class_string }}">
+        <div class="{{ width_class_string }}">
     {% endif %}
       {% block content %}
           {{ content }}
       {% endblock %}
-    {% if paragraph.sa_col.value is not empty %}
+    {% if paragraph.sa_width.value is not empty %}
         </div>
       </div>
     {% endif %}


### PR DESCRIPTION
## Description
Teamwork Ticket(s): [Rename machine names for Container and Width](https://kanopi.teamwork.com/app/tasks/29484155)

> Currently the machine name for Container is sa_width and the machine name for Width is sa_col.

Please update the field storage name for Container to be sa_container and the Width Field to be sa_width.

All field names and configs will need to be updated with the changes. Templates in saplings_child will also need to be updated as well.


## Acceptance Criteria
* Machine names have been updated for container and width in templates
