### PR TITLE
Saplings Components

### DIFF
--- a/assets/scss/custom/_overrides.scss
+++ b/assets/scss/custom/_overrides.scss
@@ -41,3 +41,7 @@ em.placeholder {
   background-color: transparent;
   opacity: 1;
 }
+
+lite-youtube {
+  max-width: 100%;
+}

--- a/templates/overrides/fields/field--node--sa-body--sa-event.html.twig
+++ b/templates/overrides/fields/field--node--sa-body--sa-event.html.twig
@@ -55,7 +55,7 @@
     multiple and label_display == 'inline' ? 'float-start'
   ]
 }) %}
-<div{{ attributes.addClass('field--name-sa-body', 'container', 'mt-3') }}>
+<div{{ attributes.addClass('field--name-sa-body', 'mt-3') }}>
   {% if not label_hidden %}
     <div{{ title_attributes.addClass(title_classes) }}>{{ label }}</div>
   {% endif %}

--- a/templates/overrides/node/node.html.twig
+++ b/templates/overrides/node/node.html.twig
@@ -99,7 +99,7 @@
   {% else %}
     {# Prints a nice image header. #}
     {% if content.sa_featured_image[0] is not empty %}
-      <div class="page-header{% if header_position is not empty %} {{ header_position }}{% endif %}"{% if overlay_level is not empty %} data-overlay="{{ overlay_level }}{% endif %}">
+      <div class="page-header mb-lg-0 mb-3 {% if header_position is not empty %} {{ header_position }}{% endif %}"{% if overlay_level is not empty %} data-overlay="{{ overlay_level }}{% endif %}">
         {{ content.sa_featured_image }}
         <div class="page-header__meta">
     {# If there is no image, print a simple header. #}

--- a/templates/overrides/paragaphs/paragraph--sa-filtered-list.html.twig
+++ b/templates/overrides/paragaphs/paragraph--sa-filtered-list.html.twig
@@ -72,36 +72,6 @@
   {% set bg_class_string = ' ' ~ paragraph.sa_background.value %}
 {% endif %}
 
-{% set col_gutters = '' %}
-{% if paragraph.sa_column_gutters.value is not empty %}
-  {% set col_gutters = paragraph.sa_column_gutters.value %}
-{% endif %}
-
-{% set col_desktop = '' %}
-{% if paragraph.sa_columns_desktop.value is not empty %}
-  {% set col_desktop = paragraph.sa_columns_desktop.value %}
-{% endif %}
-
-{% set col_tablet = '' %}
-{% if paragraph.sa_columns_tablet.value is not empty %}
-  {% set col_tablet = paragraph.sa_columns_tablet.value %}
-{% endif %}
-
-{% set col_mobile = '' %}
-{% if paragraph.sa_columns_mobile.value is not empty %}
-  {% set col_mobile = paragraph.sa_columns_mobile.value %}
-{% endif %}
-
-{% set justify = '' %}
-{% if paragraph.sa_justify_content_horizontal.value is not empty %}
-  {% set justify = ' ' ~ paragraph.sa_justify_content_horizontal.value %}
-{% endif %}
-
-{% set align = '' %}
-{% if paragraph.sa_align_items_vertically.value is not empty %}
-  {% set align = ' ' ~ paragraph.sa_align_items_vertically.value %}
-{% endif %}
-
 {% block paragraph %}
 <div{{ attributes.addClass(classes) }}>
   <div class="{{ container_class_string }}{{ bg_class_string }}{{ margin_class_string }}{{ padding_class_string }}">
@@ -109,19 +79,14 @@
       <div class="row justify-content-center">
         <div class="{{ width_class_string }}">
     {% endif %}
+    <div class="row">
+      <div class="col">
+      {{ content.sa_header}}
+      {{ content.sa_description}}
+      </div>
+    </div>
       {% block content %}
-      <div class="row">
-        <div class="col">
-          {{ content|without('sa_column_items') }}
-          </div>
-        </div>
-          <div class="row{{ justify }}{{ align }} g-{{col_gutters}} row-cols-{{col_mobile}} row-cols-md-{{col_tablet}} row-cols-lg-{{col_desktop}}">
-          {% for key,value in paragraph.sa_column_items %}
-            <div class="col">
-              {{ content.sa_column_items[key] }}
-            </div>
-          {% endfor %}
-          </div>
+          {{ content|without('sa_header', 'sa_description' )  }}
       {% endblock %}
     {% if paragraph.sa_width.value is not empty %}
         </div>

--- a/templates/overrides/paragaphs/paragraph--sa-side-by-side.html.twig
+++ b/templates/overrides/paragaphs/paragraph--sa-side-by-side.html.twig
@@ -88,12 +88,12 @@
           <div class="{{ width_class_string }}">
             <div class="row justify-content-center{{ textleft }}">
             {% endif %}
-            <div class="align-self-center col-md-6">
+            <div class="align-self-center col-md-6 mt-3 mt-lg-0">
               {% if content.sa_media is not empty %}
                 {{ content.sa_media }}
               {% endif %}
             </div>
-            <div class="align-self-center col-md-6">
+            <div class="align-self-center col-md-6 mt-3 mt-lg-0">
               {% if content.sa_header is not empty %}
                 {{ content.sa_header }}
               {% endif %}

--- a/templates/overrides/paragaphs/paragraph--sa-text.html.twig
+++ b/templates/overrides/paragaphs/paragraph--sa-text.html.twig
@@ -72,36 +72,6 @@
   {% set bg_class_string = ' ' ~ paragraph.sa_background.value %}
 {% endif %}
 
-{% set col_gutters = '' %}
-{% if paragraph.sa_column_gutters.value is not empty %}
-  {% set col_gutters = paragraph.sa_column_gutters.value %}
-{% endif %}
-
-{% set col_desktop = '' %}
-{% if paragraph.sa_columns_desktop.value is not empty %}
-  {% set col_desktop = paragraph.sa_columns_desktop.value %}
-{% endif %}
-
-{% set col_tablet = '' %}
-{% if paragraph.sa_columns_tablet.value is not empty %}
-  {% set col_tablet = paragraph.sa_columns_tablet.value %}
-{% endif %}
-
-{% set col_mobile = '' %}
-{% if paragraph.sa_columns_mobile.value is not empty %}
-  {% set col_mobile = paragraph.sa_columns_mobile.value %}
-{% endif %}
-
-{% set justify = '' %}
-{% if paragraph.sa_justify_content_horizontal.value is not empty %}
-  {% set justify = ' ' ~ paragraph.sa_justify_content_horizontal.value %}
-{% endif %}
-
-{% set align = '' %}
-{% if paragraph.sa_align_items_vertically.value is not empty %}
-  {% set align = ' ' ~ paragraph.sa_align_items_vertically.value %}
-{% endif %}
-
 {% block paragraph %}
 <div{{ attributes.addClass(classes) }}>
   <div class="{{ container_class_string }}{{ bg_class_string }}{{ margin_class_string }}{{ padding_class_string }}">
@@ -109,20 +79,13 @@
       <div class="row justify-content-center">
         <div class="{{ width_class_string }}">
     {% endif %}
+    <div class="row">
+      <div class="col">
       {% block content %}
-      <div class="row">
-        <div class="col">
-          {{ content|without('sa_column_items') }}
-          </div>
-        </div>
-          <div class="row{{ justify }}{{ align }} g-{{col_gutters}} row-cols-{{col_mobile}} row-cols-md-{{col_tablet}} row-cols-lg-{{col_desktop}}">
-          {% for key,value in paragraph.sa_column_items %}
-            <div class="col">
-              {{ content.sa_column_items[key] }}
-            </div>
-          {% endfor %}
-          </div>
+          {{ content }}
       {% endblock %}
+      </div>
+    </div>
     {% if paragraph.sa_width.value is not empty %}
         </div>
       </div>

--- a/templates/overrides/paragaphs/paragraph.html.twig
+++ b/templates/overrides/paragaphs/paragraph.html.twig
@@ -79,9 +79,19 @@
       <div class="row justify-content-center">
         <div class="{{ width_class_string }}">
     {% endif %}
+    <div class="row">
+      <div class="col">
+      {{ content.sa_header}}
+      {{ content.sa_description}}
+      </div>
+    </div>
+    <div class="row">
+      <div class="col">
       {% block content %}
-          {{ content }}
+          {{ content|without('sa_header', 'sa_description' )  }}
       {% endblock %}
+      </div>
+      </div>
     {% if paragraph.sa_width.value is not empty %}
         </div>
       </div>

--- a/templates/patterns/simple_card/pattern-simple-card.html.twig
+++ b/templates/patterns/simple_card/pattern-simple-card.html.twig
@@ -1,5 +1,5 @@
 {% if variant and variant|lower == 'horizontal' %}
-  <div{{ attributes.addClass('card') }}>
+  <div{{ attributes.addClass('card h-100') }}>
     <div class="row g-0">
       <div class="{{ image_col_classes|default('col-md-4') }}">
         {{ image|add_class('img-fluid rounded-start') }}


### PR DESCRIPTION
## Description

NOTE: I have deployed the theme changes here so that they can be seen.  https://pr-34-saplingscms.pantheonsite.io/
https://github.com/kanopi/saplingscms/pull/34

Saplings Components - Columns/Filtered List Element Alignment
Two comments here, and the attached screenshot will help illustrate them.

The Header, Subtext and Cards should all share the same left edge; currently the Cards are slightly indented.

Second comment, based on personal experience, is that those Cards would ideally all be the same height; either matching the tallest Card or trimming so they are consistent. Having them all a different height is something I know would irk a client.

## Acceptance Criteria
* h-100 class has been added to the simple card pattern
* Filtered Lists and columns with cards align to the left and right with the Title and descriptions

## Related Ticket
https://kanopi.teamwork.com/app/tasks/29490885

## Deploy Notes
https://github.com/kanopi/saplings_child/pull/43

## Description
Saplings child - Hero - Spacing Between Header and Sub Text Tight on Mobile

## Acceptance Criteria
* margin bottom utility has been added to the page header

## Related Ticket
https://kanopi.teamwork.com/app/tasks/29490942

## Description
Saplings child - Side by Side - Tight Spacing When Stacked on Mobile

## Acceptance Criteria
* margin top utility for mobile has been added to the paragraph--sa-side-by-side.html.twig file

## Related Ticket
https://kanopi.teamwork.com/app/tasks/29490941

## Description
When stacked on mobile the left edge of the sidebar content is further left than the body content. Should be aligned.   This happens on the Event Content type

## Acceptance Criteria
* removed container class from field--node--sa-body--sa-event.html.twig file

## Related Ticket
https://kanopi.teamwork.com/app/tasks/29490944

## Description
Saplings child - YouTube video placeholder image using the new widget is not responsive

## Acceptance Criteria
* CSS rule was added to the overrides.scss file to force the lite-youtube to be a max-width of 100%

## Related Ticket
https://kanopi.teamwork.com/app/tasks/29514936

## Deploy Notes
https://github.com/kanopi/saplings_child/pull/43
