### PR TITLE
Adds classes to hide banner on screens smaller than lg

### DIFF
--- a/templates/overrides/system/page.html.twig
+++ b/templates/overrides/system/page.html.twig
@@ -49,7 +49,7 @@
   <header>
     {% if page.banner %}
       {% block banner %}
-        <div class="navbar navbar-expand-lg navbar-dark bg-primary" id="banner">
+        <div class="navbar navbar-expand-lg navbar-dark bg-primary d-none d-lg-block" id="banner">
           <div class="container">
             <div class="row w-100">
               {{ page.banner }}


### PR DESCRIPTION
## Description
Banner menu links display one under the other.  This PR hides the banner menu on screens smaller than lg.  In another pr on saplings-theme repo the config will be added to display the banner nav underneath the main menu links.

## Related Ticket
https://kanopi.teamwork.com/app/tasks/29490939

## Deploy Notes
https://github.com/kanopi/saplings_child/pull/44
