### PR TITLE
Removes extraneous div

### DIFF
--- a/templates/overrides/paragaphs/paragraph--sa-faq-item.html.twig
+++ b/templates/overrides/paragaphs/paragraph--sa-faq-item.html.twig
@@ -50,15 +50,16 @@
 {% block paragraph %}
 <div{{ attributes.addClass(classes) }}>
   {% block content %}
-    <div class="faq" itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">
-      <div class="faq--question" itemprop="name">{{ content.sa_header }}</div>
-        <div class="faq--answer" itemscope itemprop="acceptedAnswer" itemtype="https://schema.org/Answer">
-          <div class="faq--answer-text" itemprop="text">
-            {{ content.sa_description }}
-          </div>
-        </div>
+  <div class="faq" itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">
+    <div class="faq--question" itemprop="name">
+      {{ content.sa_header }}
+    </div>
+    <div class="faq--answer" itemscope itemprop="acceptedAnswer" itemtype="https://schema.org/Answer">
+      <div class="faq--answer-text" itemprop="text">
+        {{ content.sa_description }}
       </div>
     </div>
+  </div>
   {% endblock %}
 </div>
 {% endblock paragraph %}


### PR DESCRIPTION
There was an extra div in the FAQ item paragraph template, which caused poor markup on anything past the first FAQ.

PR updates it.