### PR TITLE
adds nav_item pattern for tabs for breaking change to parent theme

### DIFF
--- a/templates/patterns/nav_item/nav_item.ui_patterns.yml
+++ b/templates/patterns/nav_item/nav_item.ui_patterns.yml
@@ -1,0 +1,30 @@
+nav_item:
+  label: "(Nav item)"
+  description: "Internal: to be used in the 'nav' components (nav, navbar-nav, etc)."
+  links:
+    - 'https://getbootstrap.com/docs/5.3/components/navs-tabs/'
+  category: "Navs and tabs"
+  settings:
+    active:
+      type: "boolean"
+      label: "Active link"
+      description: "Css class for whether the link corresponds to the current url."
+    disabled:
+      type: "boolean"
+      label: "Disabled link"
+      description: "Html attribute to render the link unclickable."
+    toggle:
+      type: "machine_name"
+      label: "Toggle"
+      description: "The HTML ID of the pane to activate."
+  fields:
+    link:
+      type: "render"
+      label: "Link"
+      description: "The link item."
+      preview:
+        type: 'html_tag'
+        tag: 'a'
+        value: 'Link'
+        attributes:
+          href: 'https://example.com'

--- a/templates/patterns/nav_item/pattern-nav-item--preview.html.twig
+++ b/templates/patterns/nav_item/pattern-nav-item--preview.html.twig
@@ -1,0 +1,3 @@
+<ul class="nav">
+  {{ include('pattern-nav-item.html.twig') }}
+</ul>

--- a/templates/patterns/nav_item/pattern-nav-item.html.twig
+++ b/templates/patterns/nav_item/pattern-nav-item.html.twig
@@ -1,0 +1,7 @@
+<li{{ attributes.addClass('nav-item') }}>
+  {% set link = active ? link|add_class('active') : link %}
+  {% set link = disabled ? link|add_class('disabled') : link %}
+  {% set link = toggle ? link|set_attribute('role', 'tab')|set_attribute('data-bs-toggle', 'tab') : link %}
+  {% set link = toggle ? link|set_attribute('aria-controls', toggle)|set_attribute('data-bs-target', '#' ~ toggle) : link %}
+  {{ link|add_class('nav-link') }}
+</li>


### PR DESCRIPTION
## Description
A breaking change will be coming in the next 2 weeks to the parent theme of UI Suite for our Tabs component.  We will need to add the nav_item pattern to our child themes to ensure that the theme won't break as the nav_item pattern is being removed from the parent.
https://git.drupalcode.org/project/ui_suite_bootstrap/-/merge_requests/202/diffs#8122c83ec084c2824f19c5460123cf42fe2abd0b


## Acceptance Criteria
* A list describing how the feature should behave
* e.g. Clicking outside a modal will close it
* e.g. Clicking on a new accordion tab will not close open tabs

## Assumptions
Adding this directory proactively will not effect your current site, but will stop the site from breaking once the ui_suite_bootstrap update has been deployed.

## Steps to Validate
1. Install the development version of the theme.  
2. Install the patch
3. Confirm that the site will display errors that patterns are missing
4. Add the nav_item pattern to your child theme
5. Confirm that no further changes need to be make and the tabbed items work as expected.

## Related Task
https://kanopi.teamwork.com/app/tasks/29610064

## Deploy Notes
_Notes regarding deployment of the contained body of work. These should note any
new dependencies, new scripts, etc. This should also include work that needs to be 
accomplished post-launch like enabling a plugin._
