### PR TITLE
Fix image object fit

### DIFF
--- a/assets/scss/custom/_hero.scss
+++ b/assets/scss/custom/_hero.scss
@@ -127,6 +127,14 @@
 .page-header {
   @include media-breakpoint-up(lg) {
     min-height: 55vh;
+    overflow: hidden;
+  }
+
+  &.image {
+    img {
+      object-fit: cover;
+      // height: unset;
+    }
   }
 
   &.video {

--- a/assets/scss/custom/_hero.scss
+++ b/assets/scss/custom/_hero.scss
@@ -36,10 +36,10 @@
   .hero-image {
       width: 100%;
       height: 100%;
-      position: absolute;
       top: 0;
       left: 0;
       aspect-ratio: 16 / 9;
+      position: unset !important;
 
       @include media-breakpoint-down(lg) {
           position: relative !important;
@@ -130,16 +130,9 @@
     overflow: hidden;
   }
 
-  &.image {
-    img {
-      object-fit: cover;
-      // height: unset;
-    }
-  }
-
   &.video {
     @include media-breakpoint-up(lg) {
-        aspect-ratio: 16 / 9;
+        
     }
 
     video {
@@ -152,11 +145,11 @@
 .hero-image-page { 
   width: 100%;
   height: 100%;
-  position: absolute;
   top: 0;
   left: 0;
   aspect-ratio: 16 / 9;
   z-index: 0 !important;
+  position: unset !important;
 
   @include media-breakpoint-down(lg) {
       position: relative !important;


### PR DESCRIPTION
## Description
Teamwork Ticket(s): [Change Featured Image to Featured Media](https://kanopi.teamwork.com/app/tasks/29614418)

> Change image and video to display with aspect-ratio of 16:9 instead of object fit

## Steps to Validate
1. Create a Hero component or Hero field on the Page CT
2. Confirm that image ratio is 16:9